### PR TITLE
記事中でシンタックスハイライトできるようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "core-js": "^3.6.5",
     "firebase": "^7.15.5",
     "firestore": "^1.1.6",
+    "highlightjs": "^9.16.2",
     "marked": "^1.1.1",
     "moment": "^2.27.0",
     "vue": "^2.6.11",

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -114,6 +114,7 @@ img {
   --color-text-dimmed: #456;
   --color-text-dark: #233;
   --color-background: #f6f6f6;
-  --color-background-dark: #def;
+  --color-background-dimmed: #def;
+  --color-background-dark: #233;
   --color-border-light: #ccc;
 }

--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -46,6 +46,13 @@ p {
   }
 }
 
+pre > code {
+  display: block;
+  max-width: 100%;
+  overflow: scroll;
+  background-color: var(--color-background-dark);
+}
+
 code {
   display: inline-block;
   padding: 0 6px;
@@ -55,11 +62,23 @@ code {
   border-radius: 3px;
 }
 
+blockquote {
+  margin: 2px 0 17px;
+  font-size: inherit;
+  background-color: var(--color-background);
+  border-radius: 3px;
+  font-style: italic;
+}
+blockquote p {
+  padding: 8px 12px;
+  margin: 0;
+}
+
 hr {
   display: block;
   height: 3px;
   width: 100%;
-  background-color: var(--color-background-dark);
+  background-color: var(--color-background-dimmed);
 }
 
 main {
@@ -98,6 +117,10 @@ article > h2 > span {
   /* use it as posted-date */
   font-size: 13px;
   font-weight: 200;
+}
+
+article a {
+  display: inline-block;
 }
 
 article ul {

--- a/src/assets/css/highlightjs/monokai-sublime.css
+++ b/src/assets/css/highlightjs/monokai-sublime.css
@@ -1,0 +1,83 @@
+/*
+Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-license.org/
+*/
+
+pre > code,
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #23241f;
+}
+
+pre > code,
+.hljs,
+.hljs-tag,
+.hljs-subst {
+  color: #f8f8f2;
+}
+
+.hljs-strong,
+.hljs-emphasis {
+  color: #a8a8a2;
+}
+
+.hljs-bullet,
+.hljs-quote,
+.hljs-number,
+.hljs-regexp,
+.hljs-literal,
+.hljs-link {
+  color: #ae81ff;
+}
+
+.hljs-code,
+.hljs-title,
+.hljs-section,
+.hljs-selector-class {
+  color: #a6e22e;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-name,
+.hljs-attr {
+  color: #f92672;
+}
+
+.hljs-symbol,
+.hljs-attribute {
+  color: #66d9ef;
+}
+
+.hljs-params,
+.hljs-class .hljs-title {
+  color: #f8f8f2;
+}
+
+.hljs-string,
+.hljs-type,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-selector-id,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-addition,
+.hljs-variable,
+.hljs-template-variable {
+  color: #e6db74;
+}
+
+.hljs-comment,
+.hljs-deletion,
+.hljs-meta {
+  color: #75715e;
+}

--- a/src/components/articles/ArticleItem.vue
+++ b/src/components/articles/ArticleItem.vue
@@ -8,6 +8,7 @@
   </article>
 </template>
 <script>
+import hljs from 'highlightjs'
 import marked from 'marked'
 import moment from 'moment'
 
@@ -25,6 +26,14 @@ export default {
       type: String,
       required: true
     }
+  },
+  created () {
+    marked.setOptions({
+      langPrefix: '',
+      highlight: (code, lang) => {
+        return hljs.highlightAuto(code, [lang]).value
+      }
+    })
   },
   computed: {
     createdAtString () {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import store from './store'
 
 import './assets/css/base.css'
 import './assets/css/common.css'
+import './assets/css/highlightjs/monokai-sublime.css'
 
 import firebase from 'firebase/app'
 import 'firebase/analytics'

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,4 +6,4 @@ module.exports = {
   //   public: "http://xxx.ngrok.io",
   //   disableHostCheck: true,
   // }
-};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5220,6 +5220,11 @@ highlight.js@^9.6.0:
   resolved "https://registry.npm.taobao.org/highlight.js/download/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha1-7SGqAB/mJSuxCj121HVzxlOf4Tw=
 
+highlightjs@^9.16.2:
+  version "9.16.2"
+  resolved "https://registry.yarnpkg.com/highlightjs/-/highlightjs-9.16.2.tgz#07ea6cc7c93340fc440734fb7abf28558f1f0fe1"
+  integrity sha512-FK1vmMj8BbEipEy8DLIvp71t5UsC7n2D6En/UfM/91PCwmOpj6f2iu0Y0coRC62KSRHHC+dquM2xMULV/X7NFg==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npm.taobao.org/hmac-drbg/download/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
## Issue

close #6 

解釈するlangは指定しないといけないので、ファイル名から勝手に推測、みたいな機能はまだついてない。
また今回に関しては、コードの中身から推測する仕組みも入れてない。

## demo

<img width="962" alt="Screen Shot 2020-08-27 at 16 07 01" src="https://user-images.githubusercontent.com/8110048/91417732-31652880-e88c-11ea-91d3-332a1119a8e6.png">
